### PR TITLE
fix: adjust section padding to prevent title wrapping on narrow screens

### DIFF
--- a/src/components/SectionContainer.vue
+++ b/src/components/SectionContainer.vue
@@ -20,7 +20,6 @@ defineProps({
 <style scoped>
 .section-container {
   width: 90%;
-  padding: 24px;
   text-align: center;
 }
 


### PR DESCRIPTION
* Remove horizontal padding
* Prevents the section title from wrapping to a new line on smaller screens
* Enhances layout consistency and improves visual alignment on mobile devices